### PR TITLE
CI: Always Pull on Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,4 +38,4 @@ jobs:
         run: scp ./Caddyfile "${{ vars.REMOTE_USER }}@${{ vars.REMOTE_DOMAIN }}:${{ vars.WORK_DIR }}/"
 
       - name: Deploy Using Docker Compose
-        run: WORK_DIR="${{ vars.WORK_DIR }}" DOMAIN="${{ vars.REMOTE_DOMAIN }}" DOCKER_HOST="ssh://${{ vars.REMOTE_USER }}@${{ vars.REMOTE_DOMAIN }}" docker compose up -d
+        run: WORK_DIR="${{ vars.WORK_DIR }}" DOMAIN="${{ vars.REMOTE_DOMAIN }}" DOCKER_HOST="ssh://${{ vars.REMOTE_USER }}@${{ vars.REMOTE_DOMAIN }}" docker compose up -d --pull always


### PR DESCRIPTION
Currently, new container versions of the same tag will not be pulled resulting in the old versions continuing to run without modification. I added a cli flag to force docker to update images on each deploy, which correctly updates the containers.